### PR TITLE
Fix hydration mismatch & lint

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,24 +1,23 @@
+import { NextIntlClientProvider } from "next-intl";
+import { getMessages } from "next-intl/server";
+import { ThemeProvider } from "@/components/theme/theme-provider";
+import { ToggleThemeButton } from "@/components/theme/toggle-theme-button";
+import "../global.css";
 
-import {NextIntlClientProvider} from 'next-intl';
-import {getMessages} from 'next-intl/server';
-import { ThemeProvider } from '@/components/theme/theme-provider'
-import { ToggleThemeButton } from '@/components/theme/toggle-theme-button'
-import '../global.css'
- 
 export default async function LocaleLayout({
   children,
-  params
+  params,
 }: {
   children: React.ReactNode;
-  params: {locale: string};
+  params: { locale: string };
 }) {
-  const {locale} = params;
+  const { locale } = params;
   // Providing all messages to the client
   // side is the easiest way to get started
   const messages = await getMessages();
- 
+
   return (
-    <html lang={locale}>
+    <html lang={locale} suppressHydrationWarning>
       <body>
         <NextIntlClientProvider messages={messages}>
           <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>

--- a/src/app/[locale]/login/page.tsx
+++ b/src/app/[locale]/login/page.tsx
@@ -1,42 +1,52 @@
-'use client'
+"use client";
 
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import Link from "next/link";
 
 export default function LoginPage() {
-    return (
-        <div className="min-h-screen flex items-center justify-center px-4 bg-background">
-            <Card className="w-full max-w-md shadow-lg rounded-2xl bg-card text-card-foreground">
-                <CardHeader>
-                    <CardTitle className="text-center text-2xl font-bold">Login</CardTitle>
-                </CardHeader>
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4 bg-background">
+      <Card className="w-full max-w-md shadow-lg rounded-2xl bg-card text-card-foreground">
+        <CardHeader>
+          <CardTitle className="text-center text-2xl font-bold">
+            Login
+          </CardTitle>
+        </CardHeader>
 
-                <CardContent className="space-y-4">
-                    <div className="space-y-1">
-                        <Label htmlFor="login">login</Label>
-                        <Input id="login" type="text" placeholder="login" />
-                    </div>
+        <CardContent className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="login">login</Label>
+            <Input id="login" type="text" placeholder="login" />
+          </div>
 
-                    <div className="space-y-1">
-                        <Label htmlFor="password">Senha</Label>
-                        <Input id="password" type="password" placeholder="••••••••" />
-                    </div>
+          <div className="space-y-1">
+            <Label htmlFor="password">Senha</Label>
+            <Input id="password" type="password" placeholder="••••••••" />
+          </div>
 
-                    <div className="text-right text-sm">
-                        <a href="/forgot-password" className="text-blue-600 hover:underline">
-                            Esqueceu a senha?
-                        </a>
-                    </div>
-                </CardContent>
+          <div className="text-right text-sm">
+            <Link
+              href="/forgot-password"
+              className="text-blue-600 hover:underline"
+            >
+              Esqueceu a senha?
+            </Link>
+          </div>
+        </CardContent>
 
-                <CardFooter>
-                    <Button className="w-full">Entrar</Button>
-                </CardFooter>
-            </Card>
-        </div>
-    )
+        <CardFooter>
+          <Button className="w-full">Entrar</Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
 }
-

--- a/src/app/[locale]/setup/page.tsx
+++ b/src/app/[locale]/setup/page.tsx
@@ -1,195 +1,197 @@
-'use client'
+"use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { useTranslations } from 'next-intl';
+import { useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
 import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardFooter,
-    CardHeader,
-    CardTitle,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
 } from "@/components/ui/card";
 import {
-    Form,
-    FormControl,
-    FormDescription,
-    FormField,
-    FormItem,
-    FormLabel,
-    FormMessage,
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 
-
 const step2Schema = z.object({
-    piholeUrl: z.string().url({ message: "Please enter a valid URL." }),
-    apiKey: z.string().min(1, { message: "API Key is required." }),
+  piholeUrl: z.string().url({ message: "Please enter a valid URL." }),
+  apiKey: z.string().min(1, { message: "API Key is required." }),
 });
 
 const Step1 = () => {
-    const t = useTranslations('Setup');
-    return (
-        <div className="flex h-full flex-col items-center justify-center space-y-4 text-center">
-            <h3 className="text-2xl font-semibold">{t('step1_title')}</h3>
-            <p className="text-muted-foreground">
-                {t('step1_description')}
-            </p>
-            <p>{t('step1_instruction')}</p>
-        </div>
-    );
+  const t = useTranslations("Setup");
+  return (
+    <div className="flex h-full flex-col items-center justify-center space-y-4 text-center">
+      <h3 className="text-2xl font-semibold">{t("step1_title")}</h3>
+      <p className="text-muted-foreground">{t("step1_description")}</p>
+      <p>{t("step1_instruction")}</p>
+    </div>
+  );
 };
 
 const Step3 = () => (
-    <div className="flex h-full flex-col items-center justify-center space-y-4 text-center">
-        <h3 className="text-2xl font-semibold">Configuration Complete!</h3>
-        <p className="text-muted-foreground">
-            You have successfully configured your dashboard.
-        </p>
-        <p>Click "Finish" to be redirected to the main page.</p>
-    </div>
+  <div className="flex h-full flex-col items-center justify-center space-y-4 text-center">
+    <h3 className="text-2xl font-semibold">Configuration Complete!</h3>
+    <p className="text-muted-foreground">
+      You have successfully configured your dashboard.
+    </p>
+    <p>Click &quot;Finish&quot; to be redirected to the main page.</p>
+  </div>
 );
 
 const LanguageSwitcher = () => {
-    const router = useRouter();
-    const pathname = usePathname();
-    const t = useTranslations('Setup');
+  const router = useRouter();
+  const pathname = usePathname();
+  const t = useTranslations("Setup");
 
-    const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-        const newLocale = e.target.value;
-        // Replace the locale part of the path
-        const newPath = pathname.replace(/\/(en|pt-br)/, `/${newLocale}`);
-        router.push(newPath);
-    };
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newLocale = e.target.value;
+    // Replace the locale part of the path
+    const newPath = pathname.replace(/\/(en|pt-br)/, `/${newLocale}`);
+    router.push(newPath);
+  };
 
-    return (
-        <div className="mb-4">
-            <label htmlFor="language-select" className="mr-2">{t('language')}:</label>
-            <select id="language-select" onChange={handleChange} defaultValue={pathname.split('/')[1]}>
-                <option value="en">English</option>
-                <option value="pt-br">Português (Brasil)</option>
-            </select>
-        </div>
-    );
+  return (
+    <div className="mb-4">
+      <label htmlFor="language-select" className="mr-2">
+        {t("language")}:
+      </label>
+      <select
+        id="language-select"
+        onChange={handleChange}
+        defaultValue={pathname.split("/")[1]}
+      >
+        <option value="en">English</option>
+        <option value="pt-br">Português (Brasil)</option>
+      </select>
+    </div>
+  );
 };
 
-
 function Page() {
-    const [step, setStep] = useState(1);
-    const router = useRouter();
-    const t = useTranslations('Setup');
+  const [step, setStep] = useState(1);
+  const router = useRouter();
+  const t = useTranslations("Setup");
 
+  const form = useForm<z.infer<typeof step2Schema>>({
+    resolver: zodResolver(step2Schema),
+    defaultValues: {
+      piholeUrl: "",
+      apiKey: "",
+    },
+  });
 
-    const form = useForm<z.infer<typeof step2Schema>>({
-        resolver: zodResolver(step2Schema),
-        defaultValues: {
-            piholeUrl: "",
-            apiKey: "",
-        },
-    });
+  const handleNext = async () => {
+    if (step === 2) {
+      const isValid = await form.trigger();
+      if (!isValid) return;
+      console.log("Step 2 Data:", form.getValues());
+    }
+    setStep((prev) => prev + 1);
+  };
 
-    const handleNext = async () => {
-        if (step === 2) {
-            const isValid = await form.trigger();
-            if (!isValid) return;
-            console.log("Step 2 Data:", form.getValues());
-        }
-        setStep((prev) => prev + 1);
-    };
+  const handleBack = () => {
+    setStep((prev) => prev - 1);
+  };
 
-    const handleBack = () => {
-        setStep((prev) => prev - 1);
-    };
+  const handleFinish = () => {
+    console.log("Setup finished!");
+    router.push("/");
+  };
 
-    const handleFinish = () => {
-        console.log("Setup finished!");
-        router.push("/");
-    };
+  return (
+    <div className="flex min-h-screen w-full items-center justify-center bg-background px-4">
+      <Card className="w-full max-w-3xl rounded-2xl shadow-lg">
+        <CardHeader>
+          <CardTitle className="text-center text-2xl font-bold">
+            {t("title")}
+          </CardTitle>
+          <CardDescription className="text-center text-sm text-muted-foreground">
+            Follow the steps to configure your dashboard. Step {step} of 3.
+          </CardDescription>
+        </CardHeader>
+        <Separator />
 
-    return (
-        <div className="flex min-h-screen w-full items-center justify-center bg-background px-4">
-            <Card className="w-full max-w-3xl rounded-2xl shadow-lg">
-                <CardHeader>
-                    <CardTitle className="text-center text-2xl font-bold">
-                        {t('title')}
-                    </CardTitle>
-                    <CardDescription className="text-center text-sm text-muted-foreground">
-                        Follow the steps to configure your dashboard. Step {step} of 3.
-                    </CardDescription>
-                </CardHeader>
-                <Separator />
+        <CardContent className="p-6 min-h-[300px] flex flex-col justify-center">
+          <LanguageSwitcher />
+          {step === 1 && <Step1 />}
+          {step === 2 && (
+            <Form {...form}>
+              <form className="space-y-6">
+                <FormField
+                  control={form.control}
+                  name="piholeUrl"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Pi-hole URL</FormLabel>
+                      <FormControl>
+                        <Input placeholder="http://pi.hole" {...field} />
+                      </FormControl>
+                      <FormDescription>
+                        The address of your Pi-hole admin interface.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="apiKey"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>API Key</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="password"
+                          placeholder="Your secret API key"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Find this in Pi-hole &gt; Settings &gt; API / Web
+                        interface.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </form>
+            </Form>
+          )}
+          {step === 3 && <Step3 />}
+        </CardContent>
 
-                <CardContent className="p-6 min-h-[300px] flex flex-col justify-center">
-                    <LanguageSwitcher />
-                    {step === 1 && <Step1 />}
-                    {step === 2 && (
-                        <Form {...form}>
-                            <form className="space-y-6">
-                                <FormField
-                                    control={form.control}
-                                    name="piholeUrl"
-                                    render={({ field }) => (
-                                        <FormItem>
-                                            <FormLabel>Pi-hole URL</FormLabel>
-                                            <FormControl>
-                                                <Input placeholder="http://pi.hole" {...field} />
-                                            </FormControl>
-                                            <FormDescription>
-                                                The address of your Pi-hole admin interface.
-                                            </FormDescription>
-                                            <FormMessage />
-                                        </FormItem>
-                                    )}
-                                />
-                                <FormField
-                                    control={form.control}
-                                    name="apiKey"
-                                    render={({ field }) => (
-                                        <FormItem>
-                                            <FormLabel>API Key</FormLabel>
-                                            <FormControl>
-                                                <Input type="password" placeholder="Your secret API key" {...field} />
-                                            </FormControl>
-                                            <FormDescription>
-                                                Find this in Pi-hole &gt; Settings &gt; API / Web interface.
-                                            </FormDescription>
-                                            <FormMessage />
-                                        </FormItem>
-                                    )}
-                                />
-                            </form>
-                        </Form>
-                    )}
-                    {step === 3 && <Step3 />}
-                </CardContent>
+        <Separator />
+        <CardFooter className="flex justify-between p-6">
+          {step > 1 ? (
+            <Button variant="outline" onClick={handleBack}>
+              Back
+            </Button>
+          ) : (
+            <div />
+          )}
 
-                <Separator />
-                <CardFooter className="flex justify-between p-6">
-                    {step > 1 ? (
-                        <Button variant="outline" onClick={handleBack}>
-                            Back
-                        </Button>
-                    ) : (
-                        <div />
-                    )}
-
-                    {step < 3 && (
-                        <Button onClick={handleNext}>Next</Button>
-                    )}
-                    {step === 3 && (
-                        <Button onClick={handleFinish}>Finish</Button>
-                    )}
-                </CardFooter>
-            </Card>
-        </div>
-    );
+          {step < 3 && <Button onClick={handleNext}>Next</Button>}
+          {step === 3 && <Button onClick={handleFinish}>Finish</Button>}
+        </CardFooter>
+      </Card>
+    </div>
+  );
 }
 
 export default Page;


### PR DESCRIPTION
## Summary
- suppress hydration mismatch in locale layout
- replace `<a>` tag with `Link` on login page
- escape quotes on setup page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862e9b6776083318179ff1f553708c3