### PR TITLE
Fix async params usage

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -9,9 +9,9 @@ export default async function LocaleLayout({
   params,
 }: {
   children: React.ReactNode;
-  params: { locale: string };
+  params: Promise<{ locale: string }>;
 }) {
-  const { locale } = params;
+  const { locale } = await params;
   // Providing all messages to the client
   // side is the easiest way to get started
   const messages = await getMessages();


### PR DESCRIPTION
## Summary
- await the promised params in locale layout

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862ed5ea3f08331b4f122539df8f4e3