### PR TITLE
Fix pt-br translations

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,9 +1,8 @@
-import type { NextConfig } from "next";
 import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n.ts');
 
-const nextConfig: NextConfig = {
+const nextConfig = {
   /* config options here */
 };
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -14,12 +14,12 @@ export default async function LocaleLayout({
   const { locale } = await params;
   // Providing all messages to the client
   // side is the easiest way to get started
-  const messages = await getMessages();
+  const messages = await getMessages({ locale });
 
   return (
     <html lang={locale} suppressHydrationWarning>
       <body>
-        <NextIntlClientProvider messages={messages}>
+        <NextIntlClientProvider locale={locale} messages={messages}>
           <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
             <div className="absolute top-4 right-4 z-50">
               <ToggleThemeButton />


### PR DESCRIPTION
## Summary
- rename `next.config.ts` to `next.config.mjs` so Next.js loads the i18n plugin
- fetch locale-specific messages and pass locale to provider

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6862f3841de08331818258ace2ffa66d