### PR TITLE
Fetch summary stats from Pi-hole

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,30 +1,31 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import { login, AuthData } from "@/lib/piholeLogin"
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+} from "@/components/ui/card"
 
 type PiholeConfig = { url: string; password: string }
-type AuthData = { sid: string; csrf: string }
 
-export default function ConnectPiholes() {
+type Summary = {
+  queries: {
+    total: number
+    blocked: number
+    percent_blocked: number
+    unique_domains: number
+  }
+}
+
+export default function SummaryPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [authResults, setAuthResults] = useState<Record<string, AuthData>>({})
+  const [summaries, setSummaries] = useState<Record<string, Summary>>({})
 
   useEffect(() => {
-    async function login(url: string, password: string): Promise<AuthData> {
-      const authRes = await fetch("/api/piholes/auth", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ url, password }),
-      })
-      if (!authRes.ok) {
-        const err = await authRes.json().catch(() => null)
-        throw new Error(err?.error || `Auth falhou em ${url}`)
-      }
-      const { sid, csrf } = (await authRes.json()) as AuthData
-      return { sid, csrf }
-    }
-
     async function testAuth(url: string, sid: string) {
       try {
         const res = await fetch(
@@ -54,7 +55,7 @@ export default function ConnectPiholes() {
       throw new Error(`Falha ao autenticar em ${url}`)
     }
 
-    async function authenticateAll() {
+    async function loadAll() {
       try {
         const confRes = await fetch("/api/piholes")
         if (!confRes.ok) throw new Error("Falha ao ler configuração")
@@ -68,16 +69,26 @@ export default function ConnectPiholes() {
           } catch {}
         }
 
-        const results: Record<string, AuthData> = {}
+        const authResults: Record<string, AuthData> = {}
+        const results: Record<string, Summary> = {}
 
         for (const { url, password } of piholes) {
           const current = storedAuth[url]
           const auth = await ensureAuth(url, password, current)
-          results[url] = auth
+          authResults[url] = auth
+
+          const summaryRes = await fetch(
+            `/api/stats/summary?url=${encodeURIComponent(url)}`,
+            { headers: { "X-FTL-SID": auth.sid } }
+          )
+          if (!summaryRes.ok) {
+            throw new Error(`Falha ao obter summary de ${url}`)
+          }
+          results[url] = (await summaryRes.json()) as Summary
         }
 
-        setAuthResults(results)
-        localStorage.setItem("piholesAuth", JSON.stringify(results))
+        setSummaries(results)
+        localStorage.setItem("piholesAuth", JSON.stringify(authResults))
       } catch (e: any) {
         setError(e.message)
       } finally {
@@ -85,19 +96,43 @@ export default function ConnectPiholes() {
       }
     }
 
-    authenticateAll()
+    loadAll()
   }, [])
 
   if (loading) return <p>Conectando aos Pi-holes…</p>
   if (error) return <p className="text-red-500">Erro: {error}</p>
 
   return (
-    <div className="grid gap-4">
-      {Object.entries(authResults).map(([url, { sid, csrf }]) => (
-        <div key={url} className="p-4 border rounded-lg">
+    <div className="space-y-6 p-4">
+      {Object.entries(summaries).map(([url, summary]) => (
+        <div key={url} className="space-y-4">
           <h4 className="font-medium">{url}</h4>
-          <p>SID: <code>{sid}</code></p>
-          <p>CSRF: <code>{csrf}</code></p>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>Total</CardTitle>
+              </CardHeader>
+              <CardContent>{summary.queries.total}</CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Blocked</CardTitle>
+              </CardHeader>
+              <CardContent>{summary.queries.blocked}</CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>% Blocked</CardTitle>
+              </CardHeader>
+              <CardContent>{summary.queries.percent_blocked}</CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Unique Domains</CardTitle>
+              </CardHeader>
+              <CardContent>{summary.queries.unique_domains}</CardContent>
+            </Card>
+          </div>
         </div>
       ))}
     </div>

--- a/src/app/api/stats/summary/route.ts
+++ b/src/app/api/stats/summary/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import axios from "axios";
+import https from "https";
+
+// Agente para ignorar certificados self-signed
+const httpsAgent = new https.Agent({ rejectUnauthorized: false });
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const urlParam = searchParams.get("url");
+  const sid = req.headers.get("x-ftl-sid");
+
+  if (!urlParam) {
+    return NextResponse.json(
+      { error: "Parâmetro 'url' é obrigatório" },
+      { status: 400 }
+    );
+  }
+  if (!sid) {
+    return NextResponse.json(
+      { error: "Header 'X-FTL-SID' obrigatório" },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const response = await axios.get(
+      `${urlParam.replace(/\/+$/, "")}/api/stats/summary`,
+      {
+        headers: { "X-FTL-SID": sid },
+        httpsAgent,
+        timeout: 5000,
+      }
+    );
+
+    return NextResponse.json(response.data);
+  } catch (err: any) {
+    console.error("Erro ao buscar resumo:", err.message);
+    return NextResponse.json(
+      { error: err.message || "Erro desconhecido" },
+      { status: err.response?.status || 500 }
+    );
+  }
+}

--- a/src/lib/piholeLogin.ts
+++ b/src/lib/piholeLogin.ts
@@ -1,0 +1,15 @@
+export type AuthData = { sid: string; csrf: string }
+
+export async function login(url: string, password: string): Promise<AuthData> {
+  const authRes = await fetch("/api/piholes/auth", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ url, password }),
+  })
+  if (!authRes.ok) {
+    const err = await authRes.json().catch(() => null)
+    throw new Error(err?.error || `Auth falhou em ${url}`)
+  }
+  const { sid, csrf } = (await authRes.json()) as AuthData
+  return { sid, csrf }
+}


### PR DESCRIPTION
## Summary
- extract Pi-hole login function for reuse
- add API route for `/api/stats/summary`
- update homepage to fetch summary data from all configured Pi-holes and display it in cards

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_686964e7d2708331a3c6f3d89bacbf1c