### PR TITLE
Update layout to react to collapsed SideMenu

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,8 +1,7 @@
 import { hasLocale, NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import { ThemeProvider } from "@/components/theme/theme-provider";
-import { ToggleThemeButton } from "@/components/theme/toggle-theme-button";
-import { SideMenu } from "@/components/general/side-menu";
+import LayoutWithSideMenu from "@/components/general/LayoutWithSideMenu";
 import "../global.css";
 import { notFound } from "next/navigation";
 import { routing } from '@/i18n/routing';
@@ -28,17 +27,9 @@ export default async function LocaleLayout({
           <NextIntlClientProvider locale={locale} messages={messages}>
 
             <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
-              <div className="flex min-h-screen">
-                <SideMenu />
-                <div className="relative flex-1 md:ml-64">
-                  <div className="absolute top-4 right-4 z-50">
-                    <ToggleThemeButton />
-                  </div>
-                  <div className="p-9 md:p-10">
-                    {children}
-                  </div>
-                </div>
-              </div>
+              <LayoutWithSideMenu>
+                {children}
+              </LayoutWithSideMenu>
             </ThemeProvider>
           </NextIntlClientProvider>
         </PiholeAuthProvider>

--- a/src/components/general/LayoutWithSideMenu.tsx
+++ b/src/components/general/LayoutWithSideMenu.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { ReactNode } from "react";
+import { SideMenuProvider, useSideMenu } from "@/context/SideMenuContext";
+import { SideMenu } from "./side-menu";
+import { ToggleThemeButton } from "@/components/theme/toggle-theme-button";
+import { cn } from "@/lib/utils";
+
+function LayoutContent({ children }: { children: ReactNode }) {
+  const { collapsed } = useSideMenu();
+  return (
+    <div className="flex min-h-screen">
+      <SideMenu />
+      <div className={cn("relative flex-1 transition-[margin] duration-300", collapsed ? "md:ml-14" : "md:ml-64")}> 
+        <div className="absolute top-4 right-4 z-50">
+          <ToggleThemeButton />
+        </div>
+        <div className="p-9 md:p-10">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function LayoutWithSideMenu({ children }: { children: ReactNode }) {
+  return (
+    <SideMenuProvider>
+      <LayoutContent>{children}</LayoutContent>
+    </SideMenuProvider>
+  );
+}

--- a/src/components/general/side-menu.tsx
+++ b/src/components/general/side-menu.tsx
@@ -6,11 +6,12 @@ import { Button } from "@/components/ui/button"
 import { Link } from "@/i18n/navigation"
 import { useTranslations } from "next-intl"
 import { cn } from "@/lib/utils"
+import { useSideMenu } from "@/context/SideMenuContext"
 
 export function SideMenu() {
   const t = useTranslations("Navigation")
   const [openSummary, setOpenSummary] = useState(false)
-  const [collapsed, setCollapsed] = useState(false)
+  const { collapsed, setCollapsed } = useSideMenu()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
 
   return (

--- a/src/context/SideMenuContext.tsx
+++ b/src/context/SideMenuContext.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { createContext, useContext, useState, ReactNode } from "react";
+
+interface SideMenuContextValue {
+  collapsed: boolean;
+  setCollapsed: (collapsed: boolean) => void;
+}
+
+const SideMenuContext = createContext<SideMenuContextValue | undefined>(undefined);
+
+export function SideMenuProvider({ children }: { children: ReactNode }) {
+  const [collapsed, setCollapsed] = useState(false);
+  return (
+    <SideMenuContext.Provider value={{ collapsed, setCollapsed }}>
+      {children}
+    </SideMenuContext.Provider>
+  );
+}
+
+export function useSideMenu() {
+  const context = useContext(SideMenuContext);
+  if (!context) {
+    throw new Error("useSideMenu must be used within a SideMenuProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- keep SideMenu collapsed state in context
- add LayoutWithSideMenu component to adapt margins
- use new layout component in locale layout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686a915e6a3883318b38f13697301f30