### PR TITLE
use history API route

### DIFF
--- a/src/app/api/stats/[...path]/route.ts
+++ b/src/app/api/stats/[...path]/route.ts
@@ -5,7 +5,10 @@ import https from "https";
 // Agente para ignorar certificados self-signed
 const httpsAgent = new https.Agent({ rejectUnauthorized: false });
 
-export async function GET(req: NextRequest) {
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { path: string[] } }
+) {
   const { searchParams } = new URL(req.url);
   const urlParam = searchParams.get("url");
   const sid = req.headers.get("x-ftl-sid");
@@ -24,8 +27,9 @@ export async function GET(req: NextRequest) {
   }
 
   try {
+    const endpoint = params.path.join("/");
     const response = await axios.get(
-      `${urlParam.replace(/\/+$/, "")}/api/stats/summary`,
+      `${urlParam.replace(/\/+$/, "")}/api/stats/${endpoint}`,
       {
         headers: { "X-FTL-SID": sid },
         httpsAgent,
@@ -40,7 +44,7 @@ export async function GET(req: NextRequest) {
       typeof err === "object" && err && "response" in err
         ? (err as { response?: { status?: number } }).response?.status ?? 500
         : 500;
-    console.error("Erro ao buscar resumo:", message);
+    console.error("Erro ao buscar dados:", message);
     return NextResponse.json({ error: message }, { status });
   }
 }

--- a/src/types/api/history.ts
+++ b/src/types/api/history.ts
@@ -1,0 +1,7 @@
+export type HistoryEntry = {
+  timestamp: number;
+  total: number;
+  cached: number;
+  blocked: number;
+  forwarded: number;
+};


### PR DESCRIPTION
## Summary
- expose type for Pi-hole history entries
- fetch aggregated data using `/api/stats/history`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686d23178a2c8331ba6d3c4e3414da15