### PR TITLE
Add bar chart for history

### DIFF
--- a/src/app/[locale]/(withMenu)/page.tsx
+++ b/src/app/[locale]/(withMenu)/page.tsx
@@ -6,6 +6,7 @@ import type { PiholeConfig, Summary } from "@/types/api/summary"
 import type { AuthData } from "@/services/pihole/auth"
 import { login } from "@/services/pihole/auth"
 import { FaChartPie, FaBan, FaPercent, FaGlobe } from "react-icons/fa"
+import HistoryViewer from "@/components/features/HistoryViewer/HistoryViewer"
 import { useRouter } from "next/navigation"
 
 export default function SummaryPage() {
@@ -109,11 +110,14 @@ export default function SummaryPage() {
   if (!summary) return <p>Nenhum dado carregado.</p>
 
   return (
-    <div className="flex flex-row justify-center gap-4">
-      <SummaryCard title="Total" value={summary.queries.total} icon={<FaChartPie className="w-12 h-12 text-muted-foreground" />} />
-      <SummaryCard title="Blocked" value={summary.queries.blocked} icon={<FaBan className="w-12 h-12 text-muted-foreground" />} />
-      <SummaryCard title="% Blocked" value={summary.queries.percent_blocked} isPercentage icon={<FaPercent className="w-12 h-12 text-muted-foreground" />} />
-      <SummaryCard title="Unique Domains" value={summary.queries.unique_domains} icon={<FaGlobe className="w-12 h-12 text-muted-foreground" />} />
+    <div className="space-y-8">
+      <div className="flex flex-row justify-center gap-4">
+        <SummaryCard title="Total" value={summary.queries.total} icon={<FaChartPie className="w-12 h-12 text-muted-foreground" />} />
+        <SummaryCard title="Blocked" value={summary.queries.blocked} icon={<FaBan className="w-12 h-12 text-muted-foreground" />} />
+        <SummaryCard title="% Blocked" value={summary.queries.percent_blocked} isPercentage icon={<FaPercent className="w-12 h-12 text-muted-foreground" />} />
+        <SummaryCard title="Unique Domains" value={summary.queries.unique_domains} icon={<FaGlobe className="w-12 h-12 text-muted-foreground" />} />
+      </div>
+      <HistoryViewer />
     </div>
   )
 }

--- a/src/components/features/HistoryViewer/HistoryBarChart.tsx
+++ b/src/components/features/HistoryViewer/HistoryBarChart.tsx
@@ -1,0 +1,44 @@
+import React from "react"
+import { cn } from "@/lib/utils"
+import type { HistoryEntry } from "./HistoryViewer"
+
+interface HistoryBarChartProps {
+  history: HistoryEntry[]
+  className?: string
+}
+
+export default function HistoryBarChart({ history, className }: HistoryBarChartProps) {
+  if (!history || history.length === 0) return null
+
+  const maxTotal = Math.max(...history.map(h => h.total))
+
+  return (
+    <div className={cn("flex items-end gap-2 h-48", className)}>
+      {history.map((entry, idx) => (
+        <div key={idx} className="flex flex-col items-center flex-1">
+          <div className="flex items-end gap-px h-full">
+            <div
+              className="w-2 bg-[var(--color-chart-1)]"
+              style={{ height: `${(entry.total / maxTotal) * 100}%` }}
+            />
+            <div
+              className="w-2 bg-[var(--color-chart-2)]"
+              style={{ height: `${(entry.cached / maxTotal) * 100}%` }}
+            />
+            <div
+              className="w-2 bg-[var(--color-chart-3)]"
+              style={{ height: `${(entry.blocked / maxTotal) * 100}%` }}
+            />
+            <div
+              className="w-2 bg-[var(--color-chart-4)]"
+              style={{ height: `${(entry.forwarded / maxTotal) * 100}%` }}
+            />
+          </div>
+          <span className="mt-1 text-xs font-mono">
+            {new Date(entry.timestamp * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/features/HistoryViewer/HistoryViewer.tsx
+++ b/src/components/features/HistoryViewer/HistoryViewer.tsx
@@ -3,6 +3,7 @@
 
 import { useEffect, useState, useRef } from "react"
 import { usePiholeAuth } from "@/context/PiholeAuthContext"
+import HistoryBarChart from "./HistoryBarChart"
 
 export type HistoryEntry = {
     timestamp: number
@@ -77,7 +78,8 @@ export default function HistoryViewer() {
         <div className="space-y-6 p-4">
             {Object.entries(histories).map(([url, history]) => (
                 <div key={url} className="border rounded-lg p-4">
-                    <h4 className="text-lg font-medium">Histórico de {url}</h4>
+                    <h4 className="text-lg font-medium mb-4">Histórico de {url}</h4>
+                    <HistoryBarChart history={history} className="mb-4" />
                     <ul className="list-disc ml-5">
                         {history.map((entry, idx) => (
                             <li key={idx}>


### PR DESCRIPTION
## Summary
- display bar chart for history data using simple ShadCN styled component
- render chart in HistoryViewer component

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d2f6b116483318384fde04dfa2303