### PR TITLE
Add history bar chart

### DIFF
--- a/src/components/features/history/HistoryChart.tsx
+++ b/src/components/features/history/HistoryChart.tsx
@@ -1,0 +1,54 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export interface HistoryEntry {
+  timestamp: number;
+  total: number;
+  cached: number;
+  blocked: number;
+  forwarded: number;
+}
+
+interface HistoryChartProps {
+  data: HistoryEntry[];
+}
+
+export function HistoryChart({ data }: HistoryChartProps) {
+  if (!data.length) return null;
+  const max = Math.max(...data.map((d) => d.total));
+
+  return (
+    <Card className="mt-4">
+      <CardHeader>
+        <CardTitle>History</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-end space-x-2 h-40">
+          {data.map((h) => {
+            const blockedHeight = (h.blocked / max) * 100;
+            const forwardedHeight = (h.forwarded / max) * 100;
+            const cachedHeight = (h.cached / max) * 100;
+            return (
+              <div key={h.timestamp} className="flex flex-col-reverse items-center w-6">
+                <div
+                  className="bg-[--chart-3]"
+                  style={{ height: `${cachedHeight}%` }}
+                  title={`Cached: ${h.cached}`}
+                />
+                <div
+                  className="bg-[--chart-2]"
+                  style={{ height: `${forwardedHeight}%` }}
+                  title={`Forwarded: ${h.forwarded}`}
+                />
+                <div
+                  className="bg-[--chart-1]"
+                  style={{ height: `${blockedHeight}%` }}
+                  title={`Blocked: ${h.blocked}`}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- fetch Pi-hole history data and aggregate across instances
- display a new HistoryChart component using shadcn cards
- show the chart below the summary cards on the main page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d36e48f8c833199f56ba536f866cc