### PR TITLE
Fix overview job period timezone handling

### DIFF
--- a/apps/api/src/overview/overview.service.spec.ts
+++ b/apps/api/src/overview/overview.service.spec.ts
@@ -1,6 +1,6 @@
 import { OverviewService } from "./overview.service";
 import assert from "node:assert/strict";
-import test from "node:test";
+import test, { mock } from "node:test";
 
 type OverviewJobRecord = {
   id: string;
@@ -741,6 +741,30 @@ test("runAutomaticImportRule expands all-instance rules into d-1 per-instance jo
   assert.equal(prisma.state.automaticImportRules[0].lastRunJobCount, 2);
 });
 
+test("runAutomaticImportRule keeps d-1 in the visual timezone when UTC is already the next day", async () => {
+  const { service, prisma } = createService(makeJob(), {
+    timeZone: "America/Sao_Paulo",
+    instances: [{ id: "instance-1", name: "Pi-hole A" }],
+    automaticImportRules: [
+      makeAutomaticImportRule({ id: "rule-instance", scope: "instance", instanceId: "instance-1" }),
+    ],
+  });
+
+  await (
+    service as unknown as {
+      runAutomaticImportRule(ruleId: string, reference: Date): Promise<void>;
+    }
+  ).runAutomaticImportRule("rule-instance", new Date("2026-05-16T01:45:00.000Z"));
+
+  const createdJobData = prisma.state.createdJobData as {
+    requestedFrom: Date;
+    requestedUntil: Date;
+  };
+
+  assert.equal(createdJobData.requestedFrom.toISOString(), "2026-05-14T03:00:00.000Z");
+  assert.equal(createdJobData.requestedUntil.toISOString(), "2026-05-15T02:59:59.999Z");
+});
+
 test("runAutomaticImportRule skips an instance when an import job already covers the d-1 window", async () => {
   const existingJob = makeJob({
     id: "job-existing-import",
@@ -1020,6 +1044,60 @@ test("onModuleInit preserves pending jobs and marks only running jobs as interru
     prisma.state.jobs.find((job) => job.id === "job-running")?.errorMessage,
     "Interrupted by application restart.",
   );
+});
+
+test("getOverview fallback range uses the application timezone instead of the container timezone", async () => {
+  mock.timers.enable({
+    apis: ["Date"],
+    now: new Date("2026-05-16T01:45:00.000Z"),
+  });
+
+  try {
+    const context = createService(makeJob(), {
+      instances: [{ id: "instance-1", name: "Pi-hole A" }],
+      timeZone: "America/Sao_Paulo",
+      queryRawResults: [
+        [
+          {
+            totalQueries: 0,
+            blockedQueries: 0,
+            cachedQueries: 0,
+            forwardedQueries: 0,
+            uniqueDomains: 0,
+            uniqueClients: 0,
+          },
+        ],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+    });
+
+    const result = await context.service.getOverview(
+      {
+        scope: "all",
+        groupBy: "hour",
+      } as never,
+      {
+        headers: {
+          "accept-language": "en-US",
+        },
+      } as never,
+    );
+
+    assert.equal(result.filters.from, "2026-05-08T03:00:00.000Z");
+    assert.equal(result.filters.until, "2026-05-15T02:59:59.999Z");
+    assert.equal(result.coverage.requestedFrom, "2026-05-08T03:00:00.000Z");
+    assert.equal(result.coverage.requestedUntil, "2026-05-15T02:59:59.999Z");
+  } finally {
+    mock.timers.reset();
+  }
 });
 
 test("getOverview exposes saved dates grouped by stored historical query day", async () => {

--- a/apps/api/src/overview/overview.service.ts
+++ b/apps/api/src/overview/overview.service.ts
@@ -190,14 +190,6 @@ function toIso(value: Date | null | undefined) {
   return value ? value.toISOString() : null;
 }
 
-function startOfDay(date: Date) {
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0, 0);
-}
-
-function endOfDay(date: Date) {
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999);
-}
-
 type DateTimeParts = {
   year: number;
   month: number;
@@ -350,26 +342,45 @@ function dateTimePartsInTimeZoneToDate(parts: DateTimeParts, timeZone: string) {
   return new Date(candidate);
 }
 
-function buildPreviousClosedDayRange(reference: Date, timeZone: string): HistoryRange {
-  const previousDateKey = shiftDateKey(getDateKeyInTimeZone(reference, timeZone), -1);
-  const parts = parseDateKey(previousDateKey);
+function buildClosedDayRange(reference: Date, timeZone: string, lookbackDays: number): HistoryRange {
+  const closedDateKey = shiftDateKey(getDateKeyInTimeZone(reference, timeZone), -1);
+  const startDateKey = shiftDateKey(closedDateKey, -(Math.max(1, lookbackDays) - 1));
+  const startParts = parseDateKey(startDateKey);
+  const endParts = parseDateKey(closedDateKey);
 
-  if (!parts) {
-    const previousDay = new Date(reference.getFullYear(), reference.getMonth(), reference.getDate() - 1);
+  if (!startParts || !endParts) {
+    const closedUtcDay = new Date(
+      Date.UTC(reference.getUTCFullYear(), reference.getUTCMonth(), reference.getUTCDate() - 1),
+    );
+    const startUtcDay = new Date(
+      Date.UTC(
+        closedUtcDay.getUTCFullYear(),
+        closedUtcDay.getUTCMonth(),
+        closedUtcDay.getUTCDate() - (Math.max(1, lookbackDays) - 1),
+      ),
+    );
 
     return {
-      from: startOfDay(previousDay),
-      until: endOfDay(previousDay),
+      from: new Date(
+        Date.UTC(startUtcDay.getUTCFullYear(), startUtcDay.getUTCMonth(), startUtcDay.getUTCDate(), 0, 0, 0, 0),
+      ),
+      until: new Date(
+        Date.UTC(closedUtcDay.getUTCFullYear(), closedUtcDay.getUTCMonth(), closedUtcDay.getUTCDate(), 23, 59, 59, 999),
+      ),
     };
   }
 
   return {
-    from: dateTimePartsInTimeZoneToDate({ ...parts, hour: 0, minute: 0, second: 0, millisecond: 0 }, timeZone),
-    until: dateTimePartsInTimeZoneToDate({ ...parts, hour: 23, minute: 59, second: 59, millisecond: 999 }, timeZone),
+    from: dateTimePartsInTimeZoneToDate({ ...startParts, hour: 0, minute: 0, second: 0, millisecond: 0 }, timeZone),
+    until: dateTimePartsInTimeZoneToDate({ ...endParts, hour: 23, minute: 59, second: 59, millisecond: 999 }, timeZone),
   };
 }
 
-function normalizeHistoryRange(from?: number, until?: number): HistoryRange {
+function buildPreviousClosedDayRange(reference: Date, timeZone: string): HistoryRange {
+  return buildClosedDayRange(reference, timeZone, 1);
+}
+
+function normalizeHistoryRange(from?: number, until?: number, timeZone = DEFAULT_API_TIME_ZONE): HistoryRange {
   if (from !== undefined && until !== undefined) {
     const normalizedFrom = new Date(from * 1000);
     const normalizedUntil = new Date(until * 1000);
@@ -384,17 +395,7 @@ function normalizeHistoryRange(from?: number, until?: number): HistoryRange {
     };
   }
 
-  const now = new Date();
-  const yesterday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1);
-  const rangeEnd = endOfDay(yesterday);
-  const rangeStart = startOfDay(
-    new Date(yesterday.getFullYear(), yesterday.getMonth(), yesterday.getDate() - (DEFAULT_HISTORY_LOOKBACK_DAYS - 1)),
-  );
-
-  return {
-    from: rangeStart,
-    until: rangeEnd,
-  };
+  return buildClosedDayRange(new Date(), timeZone, DEFAULT_HISTORY_LOOKBACK_DAYS);
 }
 
 function buildHistoryExpiry(reference: Date) {
@@ -521,7 +522,7 @@ export class OverviewService implements OnModuleInit, OnModuleDestroy {
       this.resolveScope(query.scope, query.instanceId, locale),
       this.readAppTimeZone(),
     ]);
-    const range = normalizeHistoryRange(query.from, query.until);
+    const range = normalizeHistoryRange(query.from, query.until, timeZone);
     const filters = this.buildQueryFilters(
       range,
       scope.instances.map((item) => item.id),
@@ -954,9 +955,12 @@ export class OverviewService implements OnModuleInit, OnModuleDestroy {
 
   async enqueueManualImport(body: CreateOverviewHistoryJobDto, request: Request): Promise<OverviewMutationResponse> {
     const locale = getRequestLocale(request);
-    const scope = await this.resolveScope(body.scope, body.instanceId, locale);
-    const range = normalizeHistoryRange(body.from, body.until);
-    await this.assertManualImportSingleDay(range);
+    const [scope, timeZone] = await Promise.all([
+      this.resolveScope(body.scope, body.instanceId, locale),
+      this.readAppTimeZone(),
+    ]);
+    const range = normalizeHistoryRange(body.from, body.until, timeZone);
+    this.assertManualImportSingleDay(range, timeZone);
     const job = await this.createJob({
       kind: "MANUAL_IMPORT",
       scope: scope.mode,
@@ -974,8 +978,11 @@ export class OverviewService implements OnModuleInit, OnModuleDestroy {
 
   async enqueueManualDelete(body: CreateOverviewHistoryJobDto, request: Request): Promise<OverviewMutationResponse> {
     const locale = getRequestLocale(request);
-    const scope = await this.resolveScope(body.scope, body.instanceId, locale);
-    const range = normalizeHistoryRange(body.from, body.until);
+    const [scope, timeZone] = await Promise.all([
+      this.resolveScope(body.scope, body.instanceId, locale),
+      this.readAppTimeZone(),
+    ]);
+    const range = normalizeHistoryRange(body.from, body.until, timeZone);
     const job = await this.createJob({
       kind: "MANUAL_DELETE",
       scope: scope.mode,
@@ -2308,9 +2315,7 @@ export class OverviewService implements OnModuleInit, OnModuleDestroy {
     return normalizeApiTimeZone(appConfig?.timeZone, DEFAULT_API_TIME_ZONE);
   }
 
-  private async assertManualImportSingleDay(range: HistoryRange) {
-    const timeZone = await this.readAppTimeZone();
-
+  private assertManualImportSingleDay(range: HistoryRange, timeZone: string) {
     if (getDateKeyInTimeZone(range.from, timeZone) !== getDateKeyInTimeZone(range.until, timeZone)) {
       throw new BadRequestException("Manual overview import is limited to a single calendar day.");
     }

--- a/apps/web/src/app/(main)/overview/_components/overview-workspace.tsx
+++ b/apps/web/src/app/(main)/overview/_components/overview-workspace.tsx
@@ -111,6 +111,7 @@ import {
   buildOverviewRankingRangeFilters,
   buildOverviewSavedDateRangeFilters,
   buildOverviewSingleDayFilters,
+  buildOverviewUtcRangeFilters,
   clampOverviewRequestFiltersToSingleDay,
   getOverviewMaxSelectableDateTime,
   type OverviewFilters,
@@ -429,13 +430,6 @@ function canOpenJobPeriod(job: OverviewJobsResponse["jobs"][number]) {
   }
 
   return job.status === "SUCCESS" || job.status === "PARTIAL";
-}
-
-function getJobPeriodSeconds(job: OverviewJobsResponse["jobs"][number]) {
-  return {
-    from: Math.floor(new Date(job.requestedFrom).getTime() / 1000),
-    until: Math.floor(new Date(job.requestedUntil).getTime() / 1000),
-  };
 }
 
 function getJobRowClassName(status: OverviewJobsResponse["jobs"][number]["status"]) {
@@ -876,6 +870,7 @@ function OverviewWorkspaceContent({
     null,
   );
   const [pendingRankingAction, setPendingRankingAction] = useState<RankingPendingAction | null>(null);
+  const [pendingOpenPeriodJobId, setPendingOpenPeriodJobId] = useState<string | null>(null);
   const [isDeletePeriodDialogOpen, setIsDeletePeriodDialogOpen] = useState(false);
   const [deleteJobDialogJobId, setDeleteJobDialogJobId] = useState<string | null>(null);
   const [deleteAutomaticImportRuleId, setDeleteAutomaticImportRuleId] = useState<string | null>(null);
@@ -1096,6 +1091,7 @@ function OverviewWorkspaceContent({
     if (!isPending) {
       setPendingRankingDrillDownSource(null);
       setPendingRankingAction(null);
+      setPendingOpenPeriodJobId(null);
     }
   }, [isPending]);
 
@@ -1781,29 +1777,22 @@ function OverviewWorkspaceContent({
     (job: OverviewJobsResponse["jobs"][number], historyMode: "push" | "replace" = "push") => {
       const nextScope: DashboardScope =
         job.scope === "instance" && job.instanceId ? { kind: "instance", instanceId: job.instanceId } : { kind: "all" };
-      const { from, until } = getJobPeriodSeconds(job);
+      const nextFilters = buildOverviewUtcRangeFilters(filters, job.requestedFrom, job.requestedUntil, timeZone);
+
+      if (!nextFilters) {
+        toast.error(messages.overview.toasts.invalidPeriod);
+        return;
+      }
 
       setClientCookie(DASHBOARD_SCOPE_COOKIE, serializeDashboardScope(nextScope));
+      setActiveTab("ranking");
+      setFilters(nextFilters);
+      setRankingReturnFilters(null);
+      setPendingRankingAction("apply");
+      setPendingOpenPeriodJobId(job.id);
 
       startTransition(() => {
-        const searchParams = new URLSearchParams({
-          tab: "ranking",
-          from: `${from}`,
-          until: `${until}`,
-          groupBy: "hour",
-        });
-        const domain = filters.domain.trim();
-        const clientIp = filters.client_ip.trim();
-
-        if (domain.length > 0) {
-          searchParams.set("domain", domain);
-        }
-
-        if (clientIp.length > 0) {
-          searchParams.set("client_ip", clientIp);
-        }
-
-        const href = `/overview?${searchParams.toString()}`;
+        const href = buildOverviewHref(nextFilters, timeZone, "ranking");
 
         if (historyMode === "replace") {
           router.replace(href);
@@ -1813,7 +1802,7 @@ function OverviewWorkspaceContent({
         router.push(href);
       });
     },
-    [filters.client_ip, filters.domain, router],
+    [filters, messages, router, timeZone],
   );
 
   const renewCoverage = async (coverageWindowId: string) => {
@@ -3532,9 +3521,11 @@ function OverviewWorkspaceContent({
                               <Button
                                 variant="outline"
                                 size="sm"
+                                className="gap-2"
                                 onClick={() => openJobPeriod(job)}
-                                disabled={busyJobAction !== null}
+                                disabled={busyJobAction !== null || pendingOpenPeriodJobId !== null}
                               >
+                                {pendingOpenPeriodJobId === job.id ? <Loader2 className="size-4 animate-spin" /> : null}
                                 {messages.overview.jobs.openPeriod}
                               </Button>
                             ) : job.status === "RUNNING" || job.status === "PENDING" ? (

--- a/apps/web/src/lib/i18n/messages.en-us.ts
+++ b/apps/web/src/lib/i18n/messages.en-us.ts
@@ -662,7 +662,7 @@ export const enUSMessages: WebMessages = {
       rankingFilters: "Saved dates and Ranking filters control the universe used by the charts and tables below.",
       rankingResults:
         "Rankings and charts are clickable where useful; clicking domains or clients applies the filter and reloads the period.",
-      jobs: "The jobs list shows imports, deletions, progress, and operational details for investigating failures or resuming runs. An automatic import also runs every day at 03:00 in the server timezone.",
+      jobs: "The jobs list shows imports, deletions, progress, and operational details for investigating failures or resuming runs. An automatic import also runs every day at 03:00 in the application-configured time zone.",
     },
     tabs: {
       request: "Period and coverage",
@@ -944,7 +944,7 @@ export const enUSMessages: WebMessages = {
     },
     settings: {
       formTitle: "Automatic import rule",
-      formDescription: (timeZone) => `Schedules are evaluated in the server timezone: ${timeZone}.`,
+      formDescription: (timeZone) => `Schedules are evaluated in the application-configured time zone: ${timeZone}.`,
       rulesTitle: "Automatic imports",
       rulesDescription: "Database-backed rules that queue historical collection jobs.",
       name: "Name",
@@ -973,7 +973,7 @@ export const enUSMessages: WebMessages = {
       applyBuilder: "Apply",
       cronExpression: "Cron",
       fixedWindowNotice: (timeZone) =>
-        `The cron controls when the rule runs; automatic collection still imports the complete d-1 day in ${timeZone}.`,
+        `The cron controls when the rule runs; automatic collection still imports the complete d-1 day in the ${timeZone} visual time zone.`,
       create: "Create rule",
       update: "Save rule",
       saving: "Saving...",

--- a/apps/web/src/lib/i18n/messages.pt-br.ts
+++ b/apps/web/src/lib/i18n/messages.pt-br.ts
@@ -668,7 +668,7 @@ export const ptBRMessages: WebMessages = {
         "As datas salvas e os filtros do Ranking controlam o universo usado nos gráficos e tabelas abaixo.",
       rankingResults:
         "Os rankings e gráficos são clicáveis quando faz sentido; clicar em domínios ou clientes aplica o filtro e recarrega o período.",
-      jobs: "A lista de jobs mostra coletas, exclusões, progresso e detalhes operacionais para investigar falhas ou retomar execuções. Também existe uma coleta automática todos os dias às 03:00 da manhã, no horário do servidor.",
+      jobs: "A lista de jobs mostra coletas, exclusões, progresso e detalhes operacionais para investigar falhas ou retomar execuções. Também existe uma coleta automática todos os dias às 03:00 no timezone configurado na aplicação.",
     },
     tabs: {
       request: "Período e cobertura",
@@ -950,7 +950,7 @@ export const ptBRMessages: WebMessages = {
     },
     settings: {
       formTitle: "Regra de importação automática",
-      formDescription: (timeZone) => `Agendamento avaliado no horário do servidor: ${timeZone}.`,
+      formDescription: (timeZone) => `Agendamento avaliado no timezone configurado na aplicação: ${timeZone}.`,
       rulesTitle: "Importações automáticas",
       rulesDescription: "Regras salvas no banco para enfileirar coletas históricas.",
       name: "Nome",
@@ -979,7 +979,7 @@ export const ptBRMessages: WebMessages = {
       applyBuilder: "Aplicar",
       cronExpression: "Cron",
       fixedWindowNotice: (timeZone) =>
-        `O cron define quando roda; a coleta automática continua importando o d-1 completo em ${timeZone}.`,
+        `O cron define quando roda; a coleta automática continua importando o d-1 completo no timezone visual ${timeZone}.`,
       create: "Criar regra",
       update: "Salvar regra",
       saving: "Salvando...",

--- a/apps/web/src/lib/overview/overview-filters.spec.ts
+++ b/apps/web/src/lib/overview/overview-filters.spec.ts
@@ -33,6 +33,12 @@ const overviewFilters = require("./overview-filters.ts") as {
     fromDate: string,
     untilDate: string,
   ) => { from: string; until: string; domain: string; client_ip: string; groupBy: "hour" | "day" };
+  buildOverviewUtcRangeFilters: (
+    filters: { from: string; until: string; domain: string; client_ip: string; groupBy: "hour" | "day" },
+    from: string | Date,
+    until: string | Date,
+    timeZone: string,
+  ) => { from: string; until: string; domain: string; client_ip: string; groupBy: "hour" | "day" } | null;
   buildOverviewRankingRangeFilters: (
     filters: { from: string; until: string; domain: string; client_ip: string; groupBy: "hour" | "day" },
     fromDate: string,
@@ -68,6 +74,7 @@ const {
   buildOverviewRankingRangeFilters,
   buildOverviewSavedDateRangeFilters,
   buildOverviewSingleDayFilters,
+  buildOverviewUtcRangeFilters,
   clampOverviewRequestFiltersToSingleDay,
   getOverviewMaxSelectableDateTime,
   normalizeOverviewFilters,
@@ -124,6 +131,24 @@ test("default overview filters use closed days in the app timezone", () => {
   assert.equal(defaults.domain, "");
   assert.equal(defaults.client_ip, "");
   assert.equal(defaults.groupBy, "hour");
+});
+
+test("default overview filters use the visual closed day even when UTC is already the next day", () => {
+  const originalNow = Date.now;
+
+  Date.now = () => Date.parse("2026-05-16T01:45:00.000Z");
+
+  try {
+    const defaults = buildDefaultOverviewFilters("America/Sao_Paulo");
+    const query = buildOverviewQueryFromFilters(defaults, "America/Sao_Paulo");
+
+    assert.equal(defaults.from, "2026-05-14T00:00");
+    assert.equal(defaults.until, "2026-05-14T23:59");
+    assert.equal(query.from, Date.parse("2026-05-14T03:00:00.000Z") / 1000);
+    assert.equal(query.until, Date.parse("2026-05-15T02:59:59.000Z") / 1000);
+  } finally {
+    Date.now = originalNow;
+  }
 });
 
 test("normalizeOverviewFilters keeps ranking filters and validates groupBy", () => {
@@ -398,6 +423,28 @@ test("buildOverviewHourBucketFilters builds the exact clicked hourly interval", 
   assert.ok(filters);
   assert.equal(filters.from, "2026-05-02T09:00");
   assert.equal(filters.until, "2026-05-02T09:59");
+  assert.equal(filters.domain, "example.com");
+  assert.equal(filters.client_ip, "192.168.1.10");
+  assert.equal(filters.groupBy, "hour");
+});
+
+test("buildOverviewUtcRangeFilters converts stored job UTC bounds into the visual timezone", () => {
+  const filters = buildOverviewUtcRangeFilters(
+    {
+      from: "2026-04-27T00:00",
+      until: "2026-04-27T23:59",
+      domain: "example.com",
+      client_ip: "192.168.1.10",
+      groupBy: "day",
+    },
+    "2026-04-28T03:00:00.000Z",
+    "2026-04-29T02:59:59.000Z",
+    "America/Sao_Paulo",
+  );
+
+  assert.ok(filters);
+  assert.equal(filters.from, "2026-04-28T00:00");
+  assert.equal(filters.until, "2026-04-28T23:59");
   assert.equal(filters.domain, "example.com");
   assert.equal(filters.client_ip, "192.168.1.10");
   assert.equal(filters.groupBy, "hour");

--- a/apps/web/src/lib/overview/overview-filters.ts
+++ b/apps/web/src/lib/overview/overview-filters.ts
@@ -288,6 +288,36 @@ export function buildOverviewHourBucketFilters(
   };
 }
 
+export function buildOverviewUtcRangeFilters(
+  filters: OverviewFilters,
+  from: string | Date,
+  until: string | Date,
+  timeZone: string,
+): OverviewFilters | null {
+  const fromMs = typeof from === "string" ? new Date(from).getTime() : from.getTime();
+  const untilMs = typeof until === "string" ? new Date(until).getTime() : until.getTime();
+
+  if (!Number.isFinite(fromMs) || !Number.isFinite(untilMs)) {
+    return null;
+  }
+
+  const normalizedFromMs = Math.min(fromMs, untilMs);
+  const normalizedUntilMs = Math.max(fromMs, untilMs);
+  const fromValue = unixSecondsToDatetimeLocal(Math.floor(normalizedFromMs / 1000), timeZone);
+  const untilValue = unixSecondsToDatetimeLocal(Math.floor(normalizedUntilMs / 1000), timeZone);
+
+  if (!fromValue || !untilValue) {
+    return null;
+  }
+
+  return {
+    ...filters,
+    from: fromValue,
+    until: untilValue,
+    groupBy: "hour",
+  };
+}
+
 export function normalizeOverviewTab(searchParams: Record<string, string | string[] | undefined>): OverviewTab {
   const tab = searchParams.tab;
   const value = Array.isArray(tab) ? (tab[0] ?? "") : (tab ?? "");

--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
   "name": "yapd",
   "version": "0.11.0",
   "private": true,
-  "workspaces": [
-    "apps/*",
-    "packages/*"
-  ],
+  "workspaces": ["apps/*", "packages/*"],
   "scripts": {
     "build": "npm run build --workspaces --if-present",
     "dev": "npm run dev:apps",
@@ -33,9 +30,7 @@
     "release:help": "node scripts/release-version.mjs --help"
   },
   "lint-staged": {
-    "*.{js,ts,jsx,tsx,json,md}": [
-      "biome check --write --no-errors-on-unmatched"
-    ]
+    "*.{js,ts,jsx,tsx,json,md}": ["biome check --write --no-errors-on-unmatched"]
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.8",


### PR DESCRIPTION
## Summary
- Preserve the configured visual timezone when calculating Overview job periods.
- Remove container-local timezone fallback behavior from Overview range handling.
- Add immediate Ranking tab feedback and a spinner when opening a completed job period.

## Validation
- `TSX_TSCONFIG_PATH=apps/web/tsconfig.json node --import tsx --test apps/web/src/lib/overview/overview-filters.spec.ts`
- `npm run test:overview --workspace @yapd/api`
- `npm run build --workspace @yapd/api`
- `npm run build --workspace @yapd/web`
- `npm run check`