### PR TITLE
ci: ignore semver-major bumps in github-actions and docker dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,10 @@ updates:
       - github-actions
     commit-message:
       prefix: ci
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: docker
     directory: "/"
@@ -47,3 +51,7 @@ updates:
       - docker
     commit-message:
       prefix: build
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
## Summary

Espelha a regra de ignore de majors do ecosystem npm pros ecosystems github-actions e docker. Sem isso, o primeiro scan do Dependabot abriu 3 PRs de major bump (actions/checkout v4→v6, actions/setup-node v4→v6, node:22→node:26).

## Test plan
- [x] Local lint passa
- [ ] CI verde no PR
- [ ] Próximo scan do Dependabot (segunda-feira ou trigger manual em Settings → Dependabot) só abre patch+minor em qualquer ecosystem

## Follow-up
Após merge, fechar os PRs #53, #54, #55 (majors que foram criados antes do fix).