### PR TITLE
fix(pihole): import Headers from undici to align with fetch types

### DIFF
--- a/apps/api/src/pihole/pihole.service.ts
+++ b/apps/api/src/pihole/pihole.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, Logger } from "@nestjs/common";
-import { Agent, fetch } from "undici";
+import { Agent, fetch, Headers } from "undici";
 
 import { DEFAULT_API_LOCALE } from "../common/i18n/locale";
 import { translateApi } from "../common/i18n/messages";


### PR DESCRIPTION
## Summary

Substitui o uso do \`Headers\` global (DOM) por \`Headers\` da undici nas duas chamadas que constroem requisições pro Pi-hole (\`apps/api/src/pihole/pihole.service.ts:1153\` e \`:1283\`).

Mudança de 1 caractere efetivo (adicionar \`Headers\` no import) que blinda o código contra o bump de undici (7.24.6 → 7.25+) que estreitou os tipos de \`HeadersInit\` e quebrou o CI do PR Dependabot #56.

## Why

O \`fetch\` do código vem de \`undici\`, mas \`new Headers(...)\` resolvia pra DOM Headers (declaração global do TS). Em undici 7.25 a interface \`HeadersInit\` ficou mais estrita e DOM Headers parou de satisfazer o tipo — \`HeadersIterator<string>\` vs \`SpecIterableIterator<string>\`.

Importando \`Headers\` da mesma lib do \`fetch\`, os tipos sempre alinham. Comportamento em runtime é idêntico (ambas implementações seguem o Web Spec).

## Test plan
- [x] \`npm run typecheck\` verde local
- [x] \`npm run check\` (Biome) verde
- [ ] CI verde no PR
- [ ] Próximo Dependabot group npm passa no CI sem o erro de \`pihole.service.ts:1193,1319\`