### PR TITLE
Endurece Nginx e bloqueia secrets default em produção

### DIFF
--- a/apps/api/src/config/app-env.ts
+++ b/apps/api/src/config/app-env.ts
@@ -3,42 +3,67 @@ import { z } from "zod";
 
 import { DEFAULT_APP_LOG_LEVEL, LOG_LEVEL_VALUES } from "../common/logging/log-levels";
 
-const envSchema = z.object({
-  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
-  LOG_LEVEL: z.enum(LOG_LEVEL_VALUES).default(DEFAULT_APP_LOG_LEVEL),
-  API_PORT: z.coerce.number().default(3001),
-  API_HOST: z.string().min(1).default("127.0.0.1"),
-  WEB_ORIGIN: z.string().min(1).default("http://localhost:3000"),
-  DATABASE_URL: z.string().min(1).default("postgresql://postgres:postgres@localhost:5432/yapd?schema=public"),
-  SESSION_COOKIE_NAME: z.string().min(1).default("yapd_session"),
-  SESSION_SECRET: z.string().min(16).default("replace-this-session-secret"),
-  YAPD_SESSION_TTL_SECONDS: z.coerce
-    .number()
-    .int()
-    .positive()
-    .default(60 * 60 * 12),
-  APP_ENCRYPTION_KEY: z.string().min(16).default("replace-this-encryption-key"),
-  PIHOLE_REQUEST_TIMEOUT_MS: z.coerce.number().int().positive().default(15_000),
-  PIHOLE_GLOBAL_MAX_CONCURRENCY: z.coerce.number().int().positive().default(4),
-  PIHOLE_PER_INSTANCE_MAX_CONCURRENCY: z.coerce.number().int().positive().default(1),
-  WEB_PUSH_VAPID_SUBJECT: z.string().min(1).default("mailto:admin@yapd.local"),
-  WEB_PUSH_VAPID_PUBLIC_KEY: z.string().trim().optional(),
-  WEB_PUSH_VAPID_PRIVATE_KEY: z.string().trim().optional(),
-  COOKIE_SECURE: z
-    .enum(["true", "false"])
-    .default("false")
-    .transform((value) => value === "true"),
-  SWAGGER_ENABLED: z
-    .enum(["true", "false"])
-    .default("true")
-    .transform((value) => value === "true"),
-  SKIP_DB_CONNECT: z
-    .enum(["true", "false"])
-    .default("false")
-    .transform((value) => value === "true"),
-  THROTTLER_TTL_MS: z.coerce.number().int().positive().default(60_000),
-  THROTTLER_LIMIT: z.coerce.number().int().positive().default(60),
-});
+const PLACEHOLDER_SESSION_SECRET = "replace-this-session-secret";
+const PLACEHOLDER_ENCRYPTION_KEY = "replace-this-encryption-key";
+
+const envSchema = z
+  .object({
+    NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+    LOG_LEVEL: z.enum(LOG_LEVEL_VALUES).default(DEFAULT_APP_LOG_LEVEL),
+    API_PORT: z.coerce.number().default(3001),
+    API_HOST: z.string().min(1).default("127.0.0.1"),
+    WEB_ORIGIN: z.string().min(1).default("http://localhost:3000"),
+    DATABASE_URL: z.string().min(1).default("postgresql://postgres:postgres@localhost:5432/yapd?schema=public"),
+    SESSION_COOKIE_NAME: z.string().min(1).default("yapd_session"),
+    SESSION_SECRET: z.string().min(16).default(PLACEHOLDER_SESSION_SECRET),
+    YAPD_SESSION_TTL_SECONDS: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(60 * 60 * 12),
+    APP_ENCRYPTION_KEY: z.string().min(16).default(PLACEHOLDER_ENCRYPTION_KEY),
+    PIHOLE_REQUEST_TIMEOUT_MS: z.coerce.number().int().positive().default(15_000),
+    PIHOLE_GLOBAL_MAX_CONCURRENCY: z.coerce.number().int().positive().default(4),
+    PIHOLE_PER_INSTANCE_MAX_CONCURRENCY: z.coerce.number().int().positive().default(1),
+    WEB_PUSH_VAPID_SUBJECT: z.string().min(1).default("mailto:admin@yapd.local"),
+    WEB_PUSH_VAPID_PUBLIC_KEY: z.string().trim().optional(),
+    WEB_PUSH_VAPID_PRIVATE_KEY: z.string().trim().optional(),
+    COOKIE_SECURE: z
+      .enum(["true", "false"])
+      .default("false")
+      .transform((value) => value === "true"),
+    SWAGGER_ENABLED: z
+      .enum(["true", "false"])
+      .default("true")
+      .transform((value) => value === "true"),
+    SKIP_DB_CONNECT: z
+      .enum(["true", "false"])
+      .default("false")
+      .transform((value) => value === "true"),
+    THROTTLER_TTL_MS: z.coerce.number().int().positive().default(60_000),
+    THROTTLER_LIMIT: z.coerce.number().int().positive().default(60),
+  })
+  .superRefine((env, ctx) => {
+    if (env.NODE_ENV !== "production") {
+      return;
+    }
+
+    if (env.SESSION_SECRET === PLACEHOLDER_SESSION_SECRET) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["SESSION_SECRET"],
+        message: "SESSION_SECRET must be set to a non-default value in production.",
+      });
+    }
+
+    if (env.APP_ENCRYPTION_KEY === PLACEHOLDER_ENCRYPTION_KEY) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["APP_ENCRYPTION_KEY"],
+        message: "APP_ENCRYPTION_KEY must be set to a non-default value in production.",
+      });
+    }
+  });
 
 export type AppEnv = z.infer<typeof envSchema>;
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -2,10 +2,17 @@ server {
     listen 80;
     server_name _;
 
+    client_max_body_size 10m;
+
+    proxy_connect_timeout 10s;
+    proxy_send_timeout 60s;
+    proxy_read_timeout 60s;
+
     # Security headers
-    add_header X-Frame-Options "SAMEORIGIN";
-    add_header X-XSS-Protection "1; mode=block";
-    add_header X-Content-Type-Options "nosniff";
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=()" always;
 
     location = /notifications-sw.js {
         proxy_pass http://127.0.0.1:3000/notifications-sw.js;
@@ -22,8 +29,9 @@ server {
         add_header Expires "0" always;
         add_header Service-Worker-Allowed "/" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-XSS-Protection "1; mode=block" always;
         add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=()" always;
     }
 
     location / {
@@ -51,10 +59,18 @@ server {
     ssl_prefer_server_ciphers on;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
 
+    client_max_body_size 10m;
+
+    proxy_connect_timeout 10s;
+    proxy_send_timeout 60s;
+    proxy_read_timeout 60s;
+
     # Security headers
-    add_header X-Frame-Options "SAMEORIGIN";
-    add_header X-XSS-Protection "1; mode=block";
-    add_header X-Content-Type-Options "nosniff";
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=()" always;
 
     location = /notifications-sw.js {
         proxy_pass http://127.0.0.1:3000/notifications-sw.js;
@@ -70,9 +86,11 @@ server {
         add_header Pragma "no-cache" always;
         add_header Expires "0" always;
         add_header Service-Worker-Allowed "/" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-XSS-Protection "1; mode=block" always;
         add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=()" always;
     }
 
     location / {


### PR DESCRIPTION
## Resumo

Dois ajustes de segurança isolados, sem refactor de comportamento. Ambos vêm do plano 13.

### 1. Nginx — headers e limites

**Adicionado**:
- \`Strict-Transport-Security: max-age=31536000; includeSubDomains\` no server HTTPS — força o navegador a usar HTTPS sempre.
- \`Referrer-Policy: strict-origin-when-cross-origin\` — só envia o origin completo pra requests same-origin; pra cross-origin envia só o host.
- \`Permissions-Policy\` desligando geolocation, microphone, camera, payment, usb — APIs que YAPD não usa.
- \`client_max_body_size 10m\` — limita body de requests (cobre uploads de CSV de listas).
- \`proxy_connect_timeout 10s\`, \`proxy_send_timeout 60s\`, \`proxy_read_timeout 60s\` — barreiras para travas longas no proxy.
- \`always\` em todos os \`add_header\` para garantir envio inclusive em respostas 4xx/5xx.

**Removido**:
- \`X-XSS-Protection: 1; mode=block\` — header **deprecated**. Navegadores modernos ignoram. Em versões antigas do Edge podia até abrir XSS via reflexão. Recomendação atual da MDN/OWASP é não enviar.

### 2. Env validation em produção

\`superRefine\` no schema Zod do \`app-env.ts\` que rejeita o boot se:
- \`NODE_ENV=production\` e \`SESSION_SECRET=replace-this-session-secret\`
- \`NODE_ENV=production\` e \`APP_ENCRYPTION_KEY=replace-this-encryption-key\`

Antes os defaults passavam pelo \`min(16)\` do Zod sem alerta. Agora subir em prod sem trocar os secrets falha imediatamente com mensagem clara apontando a env errada.

Em \`development\` e \`test\` os defaults continuam funcionando como placeholder pra DX.

## Test plan
- [x] \`npm run typecheck\` verde local
- [x] \`npm run check\` (Biome) verde
- [ ] CI verde no PR
- [ ] Após deploy: \`curl -sI https://yapd.local\` deve mostrar \`Strict-Transport-Security\`, \`Referrer-Policy\`, \`Permissions-Policy\` e **não** \`X-XSS-Protection\`
- [ ] Após deploy: \`curl -X POST ... --data-binary @file-20mb.bin\` deve retornar \`413 Request Entity Too Large\` (sem chegar no backend)
- [ ] Subir API com \`NODE_ENV=production SESSION_SECRET=replace-this-session-secret\` deve falhar no boot com mensagem descritiva

## Fora de escopo (próximos PRs do plano 13)
- **CSP** (Content-Security-Policy) — exige mapear o que Next.js + React Compiler precisam (\`unsafe-inline\`/\`unsafe-eval\`). Vai num PR próprio com Report-Only primeiro pra coletar violations.
- **Rate limiting no Nginx** (\`limit_req_zone\`) — declarations precisam ir no \`http\` block, exige reorganizar via \`/etc/nginx/conf.d/\`. PR separado.
- **Cifrar \`PushSubscription.auth\`** — blast radius maior, requer migration de dados existentes. PR dedicado.